### PR TITLE
Fixed some of the bugs

### DIFF
--- a/bin/riemann-mongodb
+++ b/bin/riemann-mongodb
@@ -10,7 +10,7 @@ class Riemann::Tools::Mongo
 
   opt :mongo_host, "Mongo hostname", :default => 'localhost'
   opt :mongo_port, "Mongo port", :default => 27017
-  opt :mongo_db, "Mongo database", :default => ''
+  opt :mongo_db, "Mongo database", :default => 'local'
 
   def initialize
     @db = ::Mongo::MongoClient.new(opts[:mongo_host], opts[:mongo_port]).db(opts[:mongo_db])

--- a/bin/riemann-mongodb-rs-status
+++ b/bin/riemann-mongodb-rs-status
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 
-# Gathers MongoDB db.stats() and submits them to Riemann.
+# Gathers MongoDB replSetGetStatus command output (rs.status() from the shell) and submits them to Riemann.
 
 require 'riemann/tools'
 
@@ -20,21 +20,37 @@ class Riemann::Tools::Mongo
 
   def tick
     begin
-      @db.command(@cmd)["members"].each do |member|
-        member.each do |property, value|
-          data = {
-            :host    => opts[:host_prefix] + member["name"],
-            :service => "mongodb #{property}",
-            :metric  => value.to_s,
-            :state   => value.to_s,
-            :tags    => ['mongodb']
-          }
-
-          report(data)
-        end
-      end
+      response = @db.command(@cmd)
+    rescue => e
+      report(
+        :host    => opts[:host_prefix] + opts[:mongo_host].dup,
+        :service => "mongodb health",
+        :description => "Connection error: #{e.class} - #{e.message}"
+      )
     end
 
+    return if response.nil?
+
+    report(
+      :host    => opts[:host_prefix] + opts[:mongo_host].dup,
+      :service => "mongodb health",
+      :state   => "ok",
+      :description => "mongodb connection status ok"
+    )
+
+    response["members"].each do |member|
+      member.each do |property, value|
+        data = {
+          :host    => opts[:host_prefix] + opts[:mongo_host].dup,
+          :service => "mongodb #{property}",
+          :metric  => value.to_s,
+          :state   => value.to_s,
+          :tags    => ['mongodb']
+        }
+
+        report(data)
+      end
+    end
   end
 
 end


### PR DESCRIPTION
1. riemann-mongodb
   - Requires some database name to connect to. By default, 'local' db comes default with fresh installation.
2. riemann-mongodb-rs-status
   - Added the functionality to handle the case when mongodb is not started with --replset argument. 
