### PR TITLE
Bump version.

### DIFF
--- a/Rakefile.rb
+++ b/Rakefile.rb
@@ -12,7 +12,7 @@ gemspec = Gem::Specification.new do |s|
   s.rubyforge_project = 'riemann-mongodb'
 
   s.name = 'riemann-mongodb'
-  s.version = '0.3.0'
+  s.version = '0.3.1'
   s.author = 'Fede Borgnia'
   s.email = 'fborgnia@gmail.com'
   s.homepage = 'https://github.com/riemann/riemann-mongodb'


### PR DESCRIPTION
So that recent changes (#4) to version constraints will be accessible from rubygems. Not sure what I need to do to get it pushed up there, don't see CI on this repo.